### PR TITLE
Fix parsing of splitted array string

### DIFF
--- a/lib/Protocol/Redis/Faster.pm
+++ b/lib/Protocol/Redis/Faster.pm
@@ -95,9 +95,8 @@ sub parse {
       }
       else {
         $self->{_curr}{data} = substr $$buf, 0, $self->{_curr}{len}, '';
+        substr $$buf, 0, 2, ''; # Remove \r\n
       }
-
-      substr $$buf, 0, 2, ''; # Remove \r\n
     }
 
     # Simple strings, errors, and integers


### PR DESCRIPTION
substr $$buf, 0, 2, ''; # Remove \r\n might remove 2 bytes if tag just parsed, but there are no array' item data. d2af44042b88103e1f5eba6251f81925a65363a