### PR TITLE
Apply new Protocol Redis version to throw on invalid version

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,7 +18,7 @@ my %WriteMakefileArgs = (
   "NAME" => "Protocol::Redis::Faster",
   "PREREQ_PM" => {
     "Carp" => 0,
-    "Protocol::Redis" => "1.0000",
+    "Protocol::Redis" => "1.0021",
     "parent" => 0
   },
   "TEST_REQUIRES" => {


### PR DESCRIPTION
Bump minimum Protocol::Redis version to make sure new constructor API has been applied